### PR TITLE
Sometimes openPhotoshopDocument() does not return a document ID

### DIFF
--- a/main.js
+++ b/main.js
@@ -295,6 +295,9 @@
             return openPhotoshopDocument(path.resolve(test.workingDir, test.input));
         })
         .then(function (id) {
+            if (!id) {
+                throw new Error("Did not get a valid document ID after opening the document");
+            }
             var activePromise = _whenActive(plugin, id);
 
             test.documentID = id;


### PR DESCRIPTION
…and now we handle that semi-gracefully (test fails).  This is a stop gap, but safe I think.  This prevents occasional generator crashes when running the tests  (at least on my machine, using a remote generator).  cc: @chrisbank 