### PR TITLE
"selected-tests" key in config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-   - "0.10"
+   - "8.11.1"
 before_script:
    - npm install -g grunt-cli
 script:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ The plug-in can be configured in your user-level `generator.json` file with the 
 1. `working-directory` - default value: a temporary directory - Indicates the directory into which assets are generated while running tests
 2. `cleanup` - default value: `true` - Indicates whether or not assets generated while runing tests should be cleaned up afterwards.
 3. `results-log-path` - Indicates the file path to which a summary of test results should be written. If not set, no results log is written.
-4. `autorun` - default value: `false` - Indicates that the automation tests should run automatically on startup. 
+4. `results-xml-path` - Desingates the file path for a Jenkins ingestable JUnit XML summary.  If not set, no xml summary will be written.
+5. `autorun` - default value: `false` - Indicates that the automation tests should run automatically on startup. 
+6. `selected-tests` - default value: `[]` - Run only tests listed in the value array.  If empty, run all.
 
 ### License
 

--- a/main.js
+++ b/main.js
@@ -188,9 +188,9 @@
         })
         .then(function (files) {
             var testDirs = files.filter(function (file) {
-                return ( file.stats.isDirectory() 
-                    && !isDisabledTestFolderName(file.filename) 
-                    && isSelectedTest(file.filename) 
+                return ( file.stats.isDirectory() &&
+                    !isDisabledTestFolderName(file.filename) &&
+                    isSelectedTest(file.filename) 
                 );
             });
 

--- a/main.js
+++ b/main.js
@@ -188,7 +188,10 @@
         })
         .then(function (files) {
             var testDirs = files.filter(function (file) {
-                return file.stats.isDirectory() && !isDisabledTestFolderName(file.filename) && isSelectedTest(file.filename);
+                return ( file.stats.isDirectory() 
+                    && !isDisabledTestFolderName(file.filename) 
+                    && isSelectedTest(file.filename) 
+                );
             });
 
             var testPromises = testDirs.map(function (file) {

--- a/main.js
+++ b/main.js
@@ -169,6 +169,12 @@
                 filename.length - DISABLED_TEST_FOLDER_SUFFIX.length);
         }
 
+        function isSelectedTest(filename) {
+            // Tests are considered selected by default unless the "selected-tests" key is present in config.
+            // If present, then check the list.
+            return ( !_config["selected-tests"] || _config["selected-tests"].indexOf(filename) > -1 );
+        }
+
         return (Q.nfcall(fse.readdir, path.resolve(__dirname, TEST_PATH_ROOT))
         .then(function (files) {
             var statPromises = files.map(function (f) {
@@ -182,7 +188,7 @@
         })
         .then(function (files) {
             var testDirs = files.filter(function (file) {
-                return file.stats.isDirectory() && !isDisabledTestFolderName(file.filename);
+                return file.stats.isDirectory() && !isDisabledTestFolderName(file.filename) && isSelectedTest(file.filename);
             });
 
             var testPromises = testDirs.map(function (file) {


### PR DESCRIPTION
This PR creates the capability of a "selected-tests" key in config where the value is an array of test names.
Instead of renaming individual test folders or selecting removing test folders, the user may enter the names of desired tests in the config file.