### PR TITLE
Revert "Compat w/ on-demand branch of generator-assets"

### DIFF
--- a/main.js
+++ b/main.js
@@ -76,13 +76,7 @@
             return plugin._status.whenIdle();
         }
 
-        var assetManager = plugin._assetManagers.get(id);
-
-        if (!assetManager) {
-            return Q.reject();
-        }
-
-        assetManager.once("idle", function () {
+        plugin._assetManagers[id].once("idle", function () {
             _idleDeferred.resolve();
             _idleDeferred = null;
             _activeDeferred = Q.defer();
@@ -97,7 +91,7 @@
             return;
         }
 
-        plugin.startAssetGeneration(documentId);
+        plugin._stateManager.activate(documentId);
     }
 
     function getTestSpecForDir(baseDir) {


### PR DESCRIPTION
Reverts adobe-photoshop/generator-assets-automation#42
Following the recent change in generator-assets, reverting this "on demand" from master.  That work will be shelved in to the `feature/on-demand` branch.  